### PR TITLE
Insert job outputs in XComs

### DIFF
--- a/airflow_xplenty/client_factory.py
+++ b/airflow_xplenty/client_factory.py
@@ -1,5 +1,22 @@
 from airflow import configuration
-from xplenty import XplentyClient
+from xplenty import Job, XplentyClient
+
+
+# Since the base XplentyClient must support v1 and v2 of the Xplenty API, the
+# core team for xplenty.py does not want to add support for features that are
+# specific to v2 of the API (e.g. the `outputs` field in the get jobs response).
+#
+# @see https://github.com/xplenty/xplenty.py/pull/23
+class XplentyV2Client(XplentyClient):
+    def get_job(self, id):
+        method_path = 'jobs/%s' % str(id)
+        url = self._join_url(method_path)
+        resp = self.get(url)
+
+        # BaseModel.new_from_dict allows us to add arbitrary attributes in
+        # **kwargs.
+        return Job.new_from_dict(resp, h=self, outputs=resp['outputs'])
+
 
 """Convenience factory for constructing an XplentyClient with proper credentials"""
 class ClientFactory:
@@ -8,4 +25,4 @@ class ClientFactory:
         self.api_key = configuration.get('xplenty', 'api_key')
 
     def client(self):
-        return XplentyClient(self.account_id, self.api_key)
+        return XplentyV2Client(self.account_id, self.api_key)

--- a/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
+++ b/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from airflow.operators.sensors import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
@@ -26,6 +27,9 @@ class XplentyWaitForJobSensor(BaseSensorOperator):
             raise Exception('Job failed: %s' % job.errors)
         elif job.status in self.SUCCESS_STATUSES:
             logging.info('Job %d finished in state %s' % (job_id, job.status))
+            print json.dumps(job.outputs, indent=4)
+            context['ti'].xcom_push(
+                key='xplenty_job_outputs', value=job.outputs)
             return True
         else:
             progress = round(job.progress * 100, 1)

--- a/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
+++ b/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
@@ -27,7 +27,7 @@ class XplentyWaitForJobSensor(BaseSensorOperator):
             raise Exception('Job failed: %s' % job.errors)
         elif job.status in self.SUCCESS_STATUSES:
             logging.info('Job %d finished in state %s' % (job_id, job.status))
-            print json.dumps(job.outputs, indent=4)
+            logging.info(json.dumps(job.outputs, indent=4))
             context['ti'].xcom_push(
                 key='xplenty_job_outputs', value=job.outputs)
             return True

--- a/tests/airflow_xplenty/test_client_factory.py
+++ b/tests/airflow_xplenty/test_client_factory.py
@@ -1,8 +1,7 @@
-import os
 import unittest
 from airflow.configuration import conf
-from airflow_xplenty.client_factory import ClientFactory
-from xplenty import XplentyClient
+from airflow_xplenty.client_factory import ClientFactory, XplentyV2Client
+
 
 class ClientFactoryTestCase(unittest.TestCase):
     def setUp(self):
@@ -14,7 +13,7 @@ class ClientFactoryTestCase(unittest.TestCase):
     def test_client_type(self):
         factory = ClientFactory()
         client = factory.client()
-        self.assertEqual(type(client), XplentyClient)
+        self.assertEqual(type(client), XplentyV2Client)
 
     def test_client_account_id(self):
         factory = ClientFactory()
@@ -25,6 +24,7 @@ class ClientFactoryTestCase(unittest.TestCase):
         factory = ClientFactory()
         client = factory.client()
         self.assertEqual(client.api_key, 'TestKey')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Also, log the output.

### Example log output
```json
[
    {
        "name": "job-10480847-units_etl-d_Nh9AHHO5disQ", 
        "component_type": "amazon_redshift_destination_component", 
        "records_count": 538220, 
        "url": "https://api.xplenty.com/apartment-list/api/jobs/10480847/outputs/16518350", 
        "created_at": "2018-02-13T21:02:56Z", 
        "updated_at": "2018-02-13T21:02:56Z", 
        "preview_url": "https://api.xplenty.com/apartment-list/api/jobs/10480847/outputs/16518350/preview", 
        "id": 16518350, 
        "component_name": "units_etl"
    }, 
    {
        "name": "job-10480847-credentials_etl-EnxNYdSNL5frIg", 
        "component_type": "amazon_redshift_destination_component", 
        "records_count": 1402, 
        "url": "https://api.xplenty.com/apartment-list/api/jobs/10480847/outputs/16518270", 
        "created_at": "2018-02-13T21:00:51Z", 
        "updated_at": "2018-02-13T21:00:51Z", 
        "preview_url": "https://api.xplenty.com/apartment-list/api/jobs/10480847/outputs/16518270/preview", 
        "id": 16518270, 
        "component_name": "credentials_etl"
    }, 
    {
        "name": "job-10480847-providers_etl-y0Qqxz5TkT80QA", 
        "component_type": "amazon_redshift_destination_component", 
        "records_count": 398, 
        "url": "https://api.xplenty.com/apartment-list/api/jobs/10480847/outputs/16518269", 
        "created_at": "2018-02-13T21:00:51Z", 
        "updated_at": "2018-02-13T21:00:51Z", 
        "preview_url": "https://api.xplenty.com/apartment-list/api/jobs/10480847/outputs/16518269/preview", 
        "id": 16518269, 
        "component_name": "providers_etl"
    }
]
```