### PR TITLE
Paginate through all clusters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 apache-airflow >= 1.8.2
-xplenty >= 1.1.0
+xplenty >= 1.1.2

--- a/tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py
+++ b/tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py
@@ -19,7 +19,9 @@ class XplentyFindOrStartClusterOperatorTestCase(unittest.TestCase):
         cluster = Mock(id=42)
         operator.client.create_cluster = MagicMock(return_value=cluster)
         terminated_cluster = Mock(id=21, type='sandbox', status='terminated')
-        operator.client.get_clusters = MagicMock(return_value=[terminated_cluster])
+        get_cluster = Mock()
+        get_cluster.side_effect = [[terminated_cluster], []]
+        operator.client.get_clusters = get_cluster
         operator.execute({})
         operator.client.create_cluster.assert_called_once_with('sandbox', 1,
             'airflow-sandbox-cluster', 'Cluster to run Airflow packages')
@@ -29,7 +31,9 @@ class XplentyFindOrStartClusterOperatorTestCase(unittest.TestCase):
         cluster = Mock(id=42)
         operator.client.create_cluster = MagicMock(return_value=cluster)
         terminated_cluster = Mock(id=21, type='production', status='available')
-        operator.client.get_clusters = MagicMock(return_value=[terminated_cluster])
+        get_cluster = Mock()
+        get_cluster.side_effect = [[terminated_cluster], []]
+        operator.client.get_clusters = get_cluster
         operator.execute({})
         operator.client.create_cluster.assert_called_once_with('sandbox', 1,
             'airflow-sandbox-cluster', 'Cluster to run Airflow packages')
@@ -44,7 +48,9 @@ class XplentyFindOrStartClusterOperatorTestCase(unittest.TestCase):
     def test_find_available_cluster(self):
         operator = XplentyFindOrStartClusterOperator(env='sandbox', task_id='test')
         terminated_cluster = Mock(id=21, type='sandbox', status='available')
-        operator.client.get_clusters = MagicMock(return_value=[terminated_cluster])
+        get_cluster = Mock()
+        get_cluster.side_effect = [[terminated_cluster], []]
+        operator.client.get_clusters = get_cluster
         self.assertEqual(operator.execute({}), 21)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Cluster pagination was introduced in v1.1.2 of `xplenty.py`. Before, we'd only see the most recent 20 clusters, which is usually fine, but can lead to mistakingly spinning up a new, redundant production cluster if the first 20 clusters are all sandbox.