### PR TITLE
Pylint improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
-  - '2.7'
+  - '2.7.14'
+  - '3.6.5'
 install:
   - pip install -r requirements-dev.txt
 script:

--- a/airflow_xplenty/client_factory.py
+++ b/airflow_xplenty/client_factory.py
@@ -2,12 +2,15 @@ from airflow import configuration
 from xplenty import Job, XplentyClient
 
 
-# Since the base XplentyClient must support v1 and v2 of the Xplenty API, the
-# core team for xplenty.py does not want to add support for features that are
-# specific to v2 of the API (e.g. the `outputs` field in the get jobs response).
-#
-# @see https://github.com/xplenty/xplenty.py/pull/23
 class XplentyV2Client(XplentyClient):
+    """
+    Since the base XplentyClient must support v1 and v2 of the Xplenty API, the
+    core team for xplenty.py does not want to add support for features that are
+    specific to v2 of the API (e.g. the `outputs` field in the get jobs
+    response).
+
+    @see https://github.com/xplenty/xplenty.py/pull/23
+    """
     def get_job(self, id):
         method_path = 'jobs/%s' % str(id)
         url = self._join_url(method_path)
@@ -18,8 +21,11 @@ class XplentyV2Client(XplentyClient):
         return Job.new_from_dict(resp, h=self, outputs=resp['outputs'])
 
 
-"""Convenience factory for constructing an XplentyClient with proper credentials"""
-class ClientFactory:
+class ClientFactory(object):
+    """
+    Convenience factory for constructing an XplentyClient with proper
+    credentials
+    """
     def __init__(self):
         self.account_id = configuration.get('xplenty', 'account_id')
         self.api_key = configuration.get('xplenty', 'api_key')

--- a/airflow_xplenty/operators/__init__.py
+++ b/airflow_xplenty/operators/__init__.py
@@ -1,7 +1,11 @@
-from airflow_xplenty.operators.xplenty_find_or_start_cluster_operator import XplentyFindOrStartClusterOperator
-from airflow_xplenty.operators.xplenty_find_or_start_job_operator import XplentyFindOrStartJobOperator
-from airflow_xplenty.operators.xplenty_wait_for_cluster_sensor import XplentyWaitForClusterSensor
-from airflow_xplenty.operators.xplenty_wait_for_job_sensor import XplentyWaitForJobSensor
+from airflow_xplenty.operators.xplenty_find_or_start_cluster_operator import \
+    XplentyFindOrStartClusterOperator
+from airflow_xplenty.operators.xplenty_find_or_start_job_operator import \
+    XplentyFindOrStartJobOperator
+from airflow_xplenty.operators.xplenty_wait_for_cluster_sensor import \
+    XplentyWaitForClusterSensor
+from airflow_xplenty.operators.xplenty_wait_for_job_sensor import \
+    XplentyWaitForJobSensor
 
 __all__ = [
     'XplentyFindOrStartClusterOperator',

--- a/airflow_xplenty/operators/xplenty_find_or_start_cluster_operator.py
+++ b/airflow_xplenty/operators/xplenty_find_or_start_cluster_operator.py
@@ -4,11 +4,11 @@ from airflow.utils.decorators import apply_defaults
 from airflow_xplenty.client_factory import ClientFactory
 
 
-"""Operator to find or start and Xplenty cluster
-
-Spin-up or re-use a cluster in the given environment ('sandbox' or 'production')
-"""
 class XplentyFindOrStartClusterOperator(BaseOperator):
+    """Operator to find or start and Xplenty cluster
+
+    Spin-up or re-use a cluster in the given environment ('sandbox' or 'production')
+    """
     TERMINATING_STATUSES = ['pending_terminate', 'terminating', 'terminated', 'error']
 
     @apply_defaults

--- a/airflow_xplenty/operators/xplenty_find_or_start_cluster_operator.py
+++ b/airflow_xplenty/operators/xplenty_find_or_start_cluster_operator.py
@@ -22,7 +22,9 @@ class XplentyFindOrStartClusterOperator(BaseOperator):
         cluster = self.__find()
         if cluster is None:
             cluster = self.__start()
-            logging.info('Starting new Xplenty %s cluster with id %d.' % (self.env, cluster.id))
+            logging.info(
+                'Starting new Xplenty %s cluster with id %d.', self.env,
+                cluster.id)
 
         return cluster.id
 
@@ -38,8 +40,8 @@ class XplentyFindOrStartClusterOperator(BaseOperator):
             for cluster in clusters:
                 if self.__is_useable(cluster):
                     logging.info(
-                        'Found existing Xplenty %s cluster with id %d.' % (
-                        self.env, cluster.id))
+                        'Found existing Xplenty %s cluster with id %d.',
+                        self.env, cluster.id)
                     return cluster
 
             offset += page_size

--- a/airflow_xplenty/operators/xplenty_find_or_start_cluster_operator.py
+++ b/airflow_xplenty/operators/xplenty_find_or_start_cluster_operator.py
@@ -55,5 +55,5 @@ class XplentyFindOrStartClusterOperator(BaseOperator):
             return False
         elif cluster.status in self.TERMINATING_STATUSES:
             return False
-        else:
-            return True
+
+        return True

--- a/airflow_xplenty/operators/xplenty_find_or_start_cluster_operator.py
+++ b/airflow_xplenty/operators/xplenty_find_or_start_cluster_operator.py
@@ -34,7 +34,7 @@ class XplentyFindOrStartClusterOperator(BaseOperator):
         page_size = 100
         while True:
             clusters = self.client.get_clusters(offset=offset, limit=page_size)
-            if len(clusters) == 0:
+            if not clusters:
                 return None
 
             for cluster in clusters:

--- a/airflow_xplenty/operators/xplenty_find_or_start_cluster_operator.py
+++ b/airflow_xplenty/operators/xplenty_find_or_start_cluster_operator.py
@@ -7,9 +7,11 @@ from airflow_xplenty.client_factory import ClientFactory
 class XplentyFindOrStartClusterOperator(BaseOperator):
     """Operator to find or start and Xplenty cluster
 
-    Spin-up or re-use a cluster in the given environment ('sandbox' or 'production')
+    Spin-up or re-use a cluster in the given environment ('sandbox' or
+    'production')
     """
-    TERMINATING_STATUSES = ['pending_terminate', 'terminating', 'terminated', 'error']
+    TERMINATING_STATUSES = ['pending_terminate', 'terminating', 'terminated',
+                            'error']
 
     @apply_defaults
     def __init__(self, env='sandbox', **kwargs):
@@ -27,7 +29,6 @@ class XplentyFindOrStartClusterOperator(BaseOperator):
                 cluster.id)
 
         return cluster.id
-
 
     def __find(self):
         offset = 0
@@ -47,8 +48,9 @@ class XplentyFindOrStartClusterOperator(BaseOperator):
             offset += page_size
 
     def __start(self):
-        return self.client.create_cluster(self.env, 1,
-            'airflow-%s-cluster' % self.env, 'Cluster to run Airflow packages')
+        return self.client.create_cluster(
+            self.env, 1, 'airflow-%s-cluster' % self.env,
+            'Cluster to run Airflow packages')
 
     def __is_useable(self, cluster):
         if cluster.type != self.env:

--- a/airflow_xplenty/operators/xplenty_find_or_start_job_operator.py
+++ b/airflow_xplenty/operators/xplenty_find_or_start_job_operator.py
@@ -56,7 +56,7 @@ class XplentyFindOrStartJobOperator(BaseOperator):
         if self.variables_fn is None:
             for job in self.client.jobs:
                 if job.package_id == self.package_id and job.status in RUNNING_STATUSES:
-                    logging.info('Found already running job %d' % job.id)
+                    logging.info('Found already running job %d', job.id)
                     return job.id
 
         if self.variables_fn is None:
@@ -66,5 +66,6 @@ class XplentyFindOrStartJobOperator(BaseOperator):
 
         job = self.client.add_job(cluster_id, self.package_id, variables)
         pretty_variables = json.dumps(variables, indent=4)
-        logging.info('Starting job %d with variables %s' % (job.id, pretty_variables))
+        logging.info(
+            'Starting job %d with variables %s', job.id, pretty_variables)
         return job.id

--- a/airflow_xplenty/operators/xplenty_find_or_start_job_operator.py
+++ b/airflow_xplenty/operators/xplenty_find_or_start_job_operator.py
@@ -11,7 +11,7 @@ def _find_package(client, name):
     page_size = 100
     while True:
         packages = client.get_packages(offset=offset, limit=page_size)
-        if len(packages) == 0:
+        if not packages:
             return None
 
         for package in packages:

--- a/airflow_xplenty/operators/xplenty_find_or_start_job_operator.py
+++ b/airflow_xplenty/operators/xplenty_find_or_start_job_operator.py
@@ -20,9 +20,10 @@ def _find_package(client, name):
 
         offset += page_size
 
-"""Operator start a job on an Xplenty cluster
-"""
+
 class XplentyFindOrStartJobOperator(BaseOperator):
+    """Operator start a job on an Xplenty cluster
+    """
     @apply_defaults
     def __init__(self, start_cluster_task_id, package_id=None,
             package_name=None, variables_fn=None, **kwargs):

--- a/airflow_xplenty/operators/xplenty_wait_for_cluster_sensor.py
+++ b/airflow_xplenty/operators/xplenty_wait_for_cluster_sensor.py
@@ -3,9 +3,11 @@ from airflow.operators.sensors import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
 from airflow_xplenty.client_factory import ClientFactory
 
-"""Wait for a cluster to be in the ready or terminating state
-"""
+
 class XplentyWaitForClusterSensor(BaseSensorOperator):
+    """
+    Wait for a cluster to be in the ready or terminating state
+    """
     TERMINATING_STATUSES = ['pending_terminate', 'terminating', 'terminated', 'error']
     READY_STATUSES = ['available', 'idle']
 

--- a/airflow_xplenty/operators/xplenty_wait_for_cluster_sensor.py
+++ b/airflow_xplenty/operators/xplenty_wait_for_cluster_sensor.py
@@ -8,7 +8,8 @@ class XplentyWaitForClusterSensor(BaseSensorOperator):
     """
     Wait for a cluster to be in the ready or terminating state
     """
-    TERMINATING_STATUSES = ['pending_terminate', 'terminating', 'terminated', 'error']
+    TERMINATING_STATUSES = ['pending_terminate', 'terminating', 'terminated',
+                            'error']
     READY_STATUSES = ['available', 'idle']
 
     @apply_defaults
@@ -19,7 +20,8 @@ class XplentyWaitForClusterSensor(BaseSensorOperator):
         super(XplentyWaitForClusterSensor, self).__init__(**kwargs)
 
     def poke(self, context):
-        cluster_id = context['task_instance'].xcom_pull(task_ids=self.start_cluster_task_id)
+        cluster_id = context['task_instance'].xcom_pull(
+            task_ids=self.start_cluster_task_id)
         if cluster_id is None:
             raise Exception('No cluster_id found in XComs')
 
@@ -28,7 +30,8 @@ class XplentyWaitForClusterSensor(BaseSensorOperator):
             logging.info('Cluster %d is ready.', cluster.id)
             return True
         elif cluster.status in self.TERMINATING_STATUSES:
-            raise Exception('Cluster failed to start, in status: %s' % cluster.status)
+            raise Exception(
+                'Cluster failed to start, in status: %s' % cluster.status)
         else:
             logging.info('Waiting for cluster %d to start.', cluster.id)
             return False

--- a/airflow_xplenty/operators/xplenty_wait_for_cluster_sensor.py
+++ b/airflow_xplenty/operators/xplenty_wait_for_cluster_sensor.py
@@ -25,10 +25,10 @@ class XplentyWaitForClusterSensor(BaseSensorOperator):
 
         cluster = self.client.get_cluster(cluster_id)
         if cluster.status in self.READY_STATUSES:
-            logging.info('Cluster %d is ready.' % cluster.id)
+            logging.info('Cluster %d is ready.', cluster.id)
             return True
         elif cluster.status in self.TERMINATING_STATUSES:
             raise Exception('Cluster failed to start, in status: %s' % cluster.status)
         else:
-            logging.info('Waiting for cluster %d to start.' % cluster.id)
+            logging.info('Waiting for cluster %d to start.', cluster.id)
             return False

--- a/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
+++ b/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
@@ -19,20 +19,22 @@ class XplentyWaitForJobSensor(BaseSensorOperator):
         super(XplentyWaitForJobSensor, self).__init__(**kwargs)
 
     def poke(self, context):
-        job_id = context['task_instance'].xcom_pull(task_ids=self.start_job_task_id)
+        job_id = context['task_instance'].xcom_pull(
+            task_ids=self.start_job_task_id)
         if job_id is None:
             raise Exception('No job_id found in XComs')
-        
+
         job = self.client.get_job(job_id)
         if job.status in self.FAILED_STATUSES:
             raise Exception('Job failed: %s' % job.errors)
         elif job.status in self.SUCCESS_STATUSES:
-            logging.info('Job %d finished in state %s' % (job_id, job.status))
+            logging.info('Job %d finished in state %s', job_id, job.status)
             logging.info(json.dumps(job.outputs, indent=4))
             context['ti'].xcom_push(
                 key='xplenty_job_outputs', value=job.outputs)
             return True
         else:
             progress = round(job.progress * 100, 1)
-            logging.info('Job %d in state %s (%.1f%%)' % (job_id, job.status, progress))
+            logging.info(
+                'Job %d in state %s (%.1f%%)', job_id, job.status, progress)
             return False

--- a/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
+++ b/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
@@ -4,9 +4,10 @@ from airflow.operators.sensors import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
 from airflow_xplenty.client_factory import ClientFactory
 
-"""Wait for a job to finish
-"""
+
 class XplentyWaitForJobSensor(BaseSensorOperator):
+    """Wait for a job to finish
+    """
     SUCCESS_STATUSES = ['completed', 'stopped']
     FAILED_STATUSES = ['failed']
 

--- a/airflow_xplenty/version.py
+++ b/airflow_xplenty/version.py
@@ -1,1 +1,1 @@
-version = '3.2.0'
+VERSION = '3.2.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 apache-airflow >= 1.8.2
-xplenty >= 1.1.2
+xplenty >= 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,24 @@
 from distutils.core import setup
 from airflow_xplenty.version import VERSION
 
+
 def do_setup():
     setup(
-      name = 'airflow_xplenty',
-      packages = ['airflow_xplenty', 'airflow_xplenty.operators'],
-      version = VERSION,
-      description = 'Airflow wrappers for the Xplenty API',
-      author = 'Tom Collier',
-      author_email = 'collier@apartmentlist.com',
-      url = 'https://github.com/apartmentlist/airflow_xplenty',
-      download_url =
-        ('https://github.com/apartmentlist/airflow_xplenty/archive/' + VERSION + '.tar.gz'),
-      keywords = ['airflow', 'xplenty'],
-      install_requires = ['apache-airflow (>= 1.8.2)', 'xplenty (>= 1.1.2)'],
-      classifiers = []
+      name='airflow_xplenty',
+      packages=['airflow_xplenty', 'airflow_xplenty.operators'],
+      version=VERSION,
+      description='Airflow wrappers for the Xplenty API',
+      author='Tom Collier',
+      author_email='collier@apartmentlist.com',
+      url='https://github.com/apartmentlist/airflow_xplenty',
+      download_url=(
+        'https://github.com/apartmentlist/airflow_xplenty/archive/' + VERSION +
+        '.tar.gz'),
+      keywords=['airflow', 'xplenty'],
+      install_requires=['apache-airflow (>= 1.8.2)', 'xplenty (>= 1.1.2)'],
+      classifiers=[]
     )
+
 
 if __name__ == "__main__":
     do_setup()

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,17 @@
 from distutils.core import setup
-from airflow_xplenty.version import version
+from airflow_xplenty.version import VERSION
 
 def do_setup():
     setup(
       name = 'airflow_xplenty',
       packages = ['airflow_xplenty', 'airflow_xplenty.operators'],
-      version = version,
+      version = VERSION,
       description = 'Airflow wrappers for the Xplenty API',
       author = 'Tom Collier',
       author_email = 'collier@apartmentlist.com',
       url = 'https://github.com/apartmentlist/airflow_xplenty',
       download_url =
-        ('https://github.com/apartmentlist/airflow_xplenty/archive/' + version + '.tar.gz'),
+        ('https://github.com/apartmentlist/airflow_xplenty/archive/' + VERSION + '.tar.gz'),
       keywords = ['airflow', 'xplenty'],
       install_requires = ['apache-airflow (>= 1.8.2)', 'xplenty (>= 1.1.2)'],
       classifiers = []

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ def do_setup():
         'https://github.com/apartmentlist/airflow_xplenty/archive/' + VERSION +
         '.tar.gz'),
       keywords=['airflow', 'xplenty'],
-      install_requires=['apache-airflow (>= 1.8.2)', 'xplenty (>= 1.1.2)'],
-      classifiers=[]
+      install_requires=['apache-airflow (>= 1.8.2)', 'xplenty (>= 1.2.0)'],
+      classifiers=['Programming Language :: Python :: 2.7',
+                   'Programming Language :: Python :: 3']
     )
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-from .airflow_xplenty import *

--- a/tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py
+++ b/tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py
@@ -5,50 +5,46 @@ from mock import Mock
 from airflow_xplenty.operators import XplentyFindOrStartClusterOperator
 
 class XplentyFindOrStartClusterOperatorTestCase(unittest.TestCase):
-    def test_execute_lazily_start_cluster(self):
-        operator = XplentyFindOrStartClusterOperator(env='sandbox', task_id='test')
+    def setUp(self):
+        self.operator = XplentyFindOrStartClusterOperator(
+            env='sandbox', task_id='test')
         cluster = Mock(id=42)
-        operator.client.create_cluster = MagicMock(return_value=cluster)
-        operator.client.get_clusters = MagicMock(return_value=[])
-        operator.execute({})
-        operator.client.create_cluster.assert_called_once_with('sandbox', 1,
-            'airflow-sandbox-cluster', 'Cluster to run Airflow packages')
+        self.operator.client.create_cluster = MagicMock(return_value=cluster)
+
+    def test_execute_lazily_start_cluster(self):
+        self.operator.client.get_clusters = MagicMock(return_value=[])
+        self.operator.execute({})
+        self.operator.client.create_cluster.assert_called_once_with(
+            'sandbox', 1, 'airflow-sandbox-cluster',
+            'Cluster to run Airflow packages')
 
     def test_execute_lazily_start_cluster_none_available(self):
-        operator = XplentyFindOrStartClusterOperator(env='sandbox', task_id='test')
-        cluster = Mock(id=42)
-        operator.client.create_cluster = MagicMock(return_value=cluster)
         terminated_cluster = Mock(id=21, type='sandbox', status='terminated')
         get_cluster = Mock()
         get_cluster.side_effect = [[terminated_cluster], []]
-        operator.client.get_clusters = get_cluster
-        operator.execute({})
-        operator.client.create_cluster.assert_called_once_with('sandbox', 1,
-            'airflow-sandbox-cluster', 'Cluster to run Airflow packages')
+        self.operator.client.get_clusters = get_cluster
+        self.operator.execute({})
+        self.operator.client.create_cluster.assert_called_once_with(
+            'sandbox', 1, 'airflow-sandbox-cluster',
+            'Cluster to run Airflow packages')
 
     def test_execute_lazily_start_cluster_wrong_env(self):
-        operator = XplentyFindOrStartClusterOperator(env='sandbox', task_id='test')
-        cluster = Mock(id=42)
-        operator.client.create_cluster = MagicMock(return_value=cluster)
         terminated_cluster = Mock(id=21, type='production', status='available')
         get_cluster = Mock()
         get_cluster.side_effect = [[terminated_cluster], []]
-        operator.client.get_clusters = get_cluster
-        operator.execute({})
-        operator.client.create_cluster.assert_called_once_with('sandbox', 1,
-            'airflow-sandbox-cluster', 'Cluster to run Airflow packages')
+        self.operator.client.get_clusters = get_cluster
+        self.operator.execute({})
+        self.operator.client.create_cluster.assert_called_once_with(
+            'sandbox', 1, 'airflow-sandbox-cluster',
+            'Cluster to run Airflow packages')
 
     def test_start_cluster_return_value(self):
-        operator = XplentyFindOrStartClusterOperator(env='sandbox', task_id='test')
-        cluster = Mock(id=42)
-        operator.client.create_cluster = MagicMock(return_value=cluster)
-        operator.client.get_clusters = MagicMock(return_value=[])
-        self.assertEqual(operator.execute({}), 42)
+        self.operator.client.get_clusters = MagicMock(return_value=[])
+        self.assertEqual(self.operator.execute({}), 42)
 
     def test_find_available_cluster(self):
-        operator = XplentyFindOrStartClusterOperator(env='sandbox', task_id='test')
-        terminated_cluster = Mock(id=21, type='sandbox', status='available')
+        available_cluster = Mock(id=21, type='sandbox', status='available')
         get_cluster = Mock()
-        get_cluster.side_effect = [[terminated_cluster], []]
-        operator.client.get_clusters = get_cluster
-        self.assertEqual(operator.execute({}), 21)
+        get_cluster.side_effect = [[available_cluster], []]
+        self.operator.client.get_clusters = get_cluster
+        self.assertEqual(self.operator.execute({}), 21)

--- a/tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py
+++ b/tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py
@@ -1,5 +1,4 @@
 import unittest
-from airflow.configuration import conf
 from mock import MagicMock
 from mock import Mock
 from airflow_xplenty.operators import XplentyFindOrStartClusterOperator

--- a/tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py
+++ b/tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py
@@ -4,6 +4,7 @@ from mock import MagicMock
 from mock import Mock
 from airflow_xplenty.operators import XplentyFindOrStartClusterOperator
 
+
 class XplentyFindOrStartClusterOperatorTestCase(unittest.TestCase):
     def setUp(self):
         self.operator = XplentyFindOrStartClusterOperator(

--- a/tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py
+++ b/tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py
@@ -52,6 +52,3 @@ class XplentyFindOrStartClusterOperatorTestCase(unittest.TestCase):
         get_cluster.side_effect = [[terminated_cluster], []]
         operator.client.get_clusters = get_cluster
         self.assertEqual(operator.execute({}), 21)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/airflow_xplenty/test_client_factory.py
+++ b/tests/airflow_xplenty/test_client_factory.py
@@ -5,7 +5,6 @@ from airflow_xplenty.client_factory import ClientFactory, XplentyV2Client
 
 class ClientFactoryTestCase(unittest.TestCase):
     def setUp(self):
-        # TODO: set these values in unittest.cfg and have Airflow read from there
         if not conf.has_section('xplenty'):
             conf.add_section('xplenty')
         conf.set('xplenty', 'account_id', 'TestAccount')

--- a/tests/airflow_xplenty/test_client_factory.py
+++ b/tests/airflow_xplenty/test_client_factory.py
@@ -24,7 +24,3 @@ class ClientFactoryTestCase(unittest.TestCase):
         factory = ClientFactory()
         client = factory.client()
         self.assertEqual(client.api_key, 'TestKey')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/airflow_xplenty/test_client_factory.py
+++ b/tests/airflow_xplenty/test_client_factory.py
@@ -6,7 +6,8 @@ from airflow_xplenty.client_factory import ClientFactory, XplentyV2Client
 class ClientFactoryTestCase(unittest.TestCase):
     def setUp(self):
         # TODO: set these values in unittest.cfg and have Airflow read from there
-        if not conf.has_section('xplenty'): conf.add_section('xplenty')
+        if not conf.has_section('xplenty'):
+            conf.add_section('xplenty')
         conf.set('xplenty', 'account_id', 'TestAccount')
         conf.set('xplenty', 'api_key', 'TestKey')
 


### PR DESCRIPTION
Inspired by @beatak's talk at ERT yesterday on all the linters, I ran `pylint` on both the `airflow_xplenty` and `tests` directories, making "easy" changes to improve the scores. For each commit that improved the pylint score, I've noted the score and improvement in the commit message. Note: not all commits are a response to pylint, e.g. limiting lines to 80 characters, and I ran pylint separately for the `airflow_xplenty` and `tests` directory, so they each have their own scores.