### PR TITLE
Add operator to terminate job

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ In addition to the standard [BaseOperator arguments](https://airflow.incubator.a
 | start_job_task_id | `String`  | True     | The task ID of a XplentyStartJobOperator  |
 
 
+### `XplentyTerminateJobOperator`
+
+This operator an existing job. It finds the job ID from the XComs.
+
+#### Arguments
+
+In addition to the standard [BaseOperator arguments](https://airflow.incubator.apache.org/code.html#baseoperator), the following are exposed
+
+|       Argument        |   Type     | Required | Description |
+|:--------------------- |:---------- |:-------- |:----------- |
+| start_job_task_id     | `String`   | True     | The task ID of a XplentyFindOrStartJobOperator  |
+
+
 #### Example
 
 ```python

--- a/airflow_xplenty/operators/__init__.py
+++ b/airflow_xplenty/operators/__init__.py
@@ -2,6 +2,8 @@ from airflow_xplenty.operators.xplenty_find_or_start_cluster_operator import \
     XplentyFindOrStartClusterOperator
 from airflow_xplenty.operators.xplenty_find_or_start_job_operator import \
     XplentyFindOrStartJobOperator
+from airflow_xplenty.operators.xplenty_terminate_job_operator import \
+    XplentyTerminateJobOperator
 from airflow_xplenty.operators.xplenty_wait_for_cluster_sensor import \
     XplentyWaitForClusterSensor
 from airflow_xplenty.operators.xplenty_wait_for_job_sensor import \
@@ -10,6 +12,7 @@ from airflow_xplenty.operators.xplenty_wait_for_job_sensor import \
 __all__ = [
     'XplentyFindOrStartClusterOperator',
     'XplentyFindOrStartJobOperator',
+    'XplentyTerminateJobOperator',
     'XplentyWaitForClusterSensor',
     'XplentyWaitForJobSensor'
 ]

--- a/airflow_xplenty/operators/xplenty_terminate_job_operator.py
+++ b/airflow_xplenty/operators/xplenty_terminate_job_operator.py
@@ -1,0 +1,25 @@
+import logging
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+from airflow_xplenty.client_factory import ClientFactory
+
+
+class XplentyTerminateJobOperator(BaseOperator):
+    """Kill a running job
+    """
+
+    @apply_defaults
+    def __init__(self, start_job_task_id, **kwargs):
+        self.start_job_task_id = start_job_task_id
+        self.client = ClientFactory().client()
+
+        super(XplentyTerminateJobOperator, self).__init__(**kwargs)
+
+    def execute(self, context):
+        job_id = context['task_instance'].xcom_pull(
+            task_ids=self.start_job_task_id)
+        if job_id is None:
+            raise Exception('No job_id found in XComs')
+
+        self.client.stop_job(job_id)
+        logging.info('Terminated job %d' % job_id)

--- a/tests/airflow_xplenty/operators/test_xplenty_terminate_job_operator.py
+++ b/tests/airflow_xplenty/operators/test_xplenty_terminate_job_operator.py
@@ -1,0 +1,18 @@
+import unittest
+from mock import MagicMock
+from mock import Mock
+from airflow_xplenty.operators import XplentyTerminateJobOperator
+
+
+class XplentyTerminateJobOperatorTestCase(unittest.TestCase):
+    def setUp(self):
+        self.operator = XplentyTerminateJobOperator(
+            start_job_task_id='start_job', task_id='test')
+        self.operator.client.stop_job = MagicMock()
+
+    def test_execute(self):
+        task_instance = Mock()
+        task_instance.xcom_pull = MagicMock(return_value=314)
+        self.operator.execute({'task_instance': task_instance})
+        task_instance.xcom_pull.assert_called_with(task_ids='start_job')
+        self.operator.client.stop_job.assert_called_once_with(314)


### PR DESCRIPTION
Add `XplentyTerminateJobOperator`, which [terminates a given job on Xplenty](https://github.com/xplenty/xplenty.py/#terminate-a-job). The operator gets the ID of the job from XComs, which is keyed by the value passed into `start_job_task_id`. This is the same process `XplentyWaitForJobSensor` uses to get the ID of the job to monitor.

This operator can be used for many purposes, including terminating a job that runs for too long.