### PR TITLE
Allow package_name to be a callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In addition to the standard [BaseOperator arguments](https://airflow.incubator.a
 |:--------------------- |:---------- |:-------- |:----------- |
 | start_cluster_task_id | `String`   | True     | The task ID of a XplentyFindOrStartClusterOperator  |
 | package_id            | `Integer`  | True*    | The ID of the package to run |
-| package_name          | `String`   | True*    | The name of the package to run |
+| package_name          | `String` or `Function`   | True*    | The name of the package to run or a callable that takes the TI context and returns a package name |
 | variables_fn          | `Function` | False    | Optional function that takes the context from #execute and returns a dict of variables to pass to the package |
 
  * Either `package_id` or `package_name` (but not both) must be supplied to the

--- a/airflow_xplenty/operators/xplenty_find_or_start_job_operator.py
+++ b/airflow_xplenty/operators/xplenty_find_or_start_job_operator.py
@@ -50,9 +50,13 @@ class XplentyFindOrStartJobOperator(BaseOperator):
             raise Exception('No cluster_id found in XComs')
 
         if self.package_name is not None:
-            package = _find_package(self.client, self.package_name)
+            if callable(self.package_name):
+                package_name = self.package_name(context)
+            else:
+                package_name = self.package_name
+            package = _find_package(self.client, package_name)
             if package is None:
-                raise Exception('Package %s not found' % self.package_name)
+                raise Exception('Package %s not found' % package_name)
             self.package_id = package.id
 
         # Only try to reuse existing running jobs when there are no variables.

--- a/tests/airflow_xplenty/operators/test_xplenty_find_or_start_job_operator.py
+++ b/tests/airflow_xplenty/operators/test_xplenty_find_or_start_job_operator.py
@@ -53,6 +53,20 @@ class XplentyFindOrStartJobOperatorTestCase(unittest.TestCase):
         self.operator.execute({'task_instance': self.task_instance})
         self.operator.client.add_job.assert_called_with(314, 24, {})
 
+    def test_execute_with_package_name_fn(self):
+        def package_name_fn(_context):
+            return 'do_stuff_from_fn'
+
+        self.init_operator(package_name=package_name_fn)
+        expected_package = Mock(id=24)
+        expected_package.name = 'do_stuff_from_fn'
+        other_package = Mock(id=23)
+        other_package.name = 'do_nada'
+        packages = [other_package, expected_package]
+        self.operator.client.get_packages = MagicMock(return_value=packages)
+        self.operator.execute({'task_instance': self.task_instance})
+        self.operator.client.add_job.assert_called_with(314, 24, {})
+
     def test_execute_with_invalid_package_name(self):
         self.init_operator(package_name='do_stuff')
         other_package = Mock(id=23)


### PR DESCRIPTION
This allows client applications to dynamically choose the Xplenty package to run based on the DAG run context.