### PR TITLE
Consider a "stopped" Xplenty job as a failure

### DIFF
--- a/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
+++ b/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
@@ -1,15 +1,18 @@
 import json
 import logging
+
 from airflow.operators.sensors import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
+
 from airflow_xplenty.client_factory import ClientFactory
 
 
 class XplentyWaitForJobSensor(BaseSensorOperator):
     """Wait for a job to finish
     """
-    SUCCESS_STATUSES = ['completed']
-    FAILED_STATUSES = ['failed', 'stopped']
+
+    SUCCESS_STATUSES = ["completed"]
+    FAILED_STATUSES = ["failed", "stopped"]
 
     @apply_defaults
     def __init__(self, start_job_task_id, **kwargs):
@@ -19,22 +22,21 @@ class XplentyWaitForJobSensor(BaseSensorOperator):
         super(XplentyWaitForJobSensor, self).__init__(**kwargs)
 
     def poke(self, context):
-        job_id = context['task_instance'].xcom_pull(
-            task_ids=self.start_job_task_id)
+        job_id = context["task_instance"].xcom_pull(task_ids=self.start_job_task_id)
         if job_id is None:
-            raise Exception('No job_id found in XComs')
+            raise Exception("No job_id found in XComs")
 
         job = self.client.get_job(job_id)
         if job.status in self.FAILED_STATUSES:
-            raise Exception('Job failed: %s' % job.errors)
+            raise Exception("Job failed: %s" % job.errors)
         elif job.status in self.SUCCESS_STATUSES:
-            logging.info('Job %d finished in state %s', job_id, job.status)
+            logging.info("Job %d finished in state %s", job_id, job.status)
             logging.info(json.dumps(job.outputs, indent=4))
-            context['task_instance'].xcom_push(
-                key='xplenty_job_outputs', value=job.outputs)
+            context["task_instance"].xcom_push(
+                key="xplenty_job_outputs", value=job.outputs
+            )
             return True
         else:
             progress = round(job.progress * 100, 1)
-            logging.info(
-                'Job %d in state %s (%.1f%%)', job_id, job.status, progress)
+            logging.info("Job %d in state %s (%.1f%%)", job_id, job.status, progress)
             return False

--- a/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
+++ b/airflow_xplenty/operators/xplenty_wait_for_job_sensor.py
@@ -8,8 +8,8 @@ from airflow_xplenty.client_factory import ClientFactory
 class XplentyWaitForJobSensor(BaseSensorOperator):
     """Wait for a job to finish
     """
-    SUCCESS_STATUSES = ['completed', 'stopped']
-    FAILED_STATUSES = ['failed']
+    SUCCESS_STATUSES = ['completed']
+    FAILED_STATUSES = ['failed', 'stopped']
 
     @apply_defaults
     def __init__(self, start_job_task_id, **kwargs):

--- a/tests/airflow_xplenty/operators/test_xplenty_wait_for_job_sensor.py
+++ b/tests/airflow_xplenty/operators/test_xplenty_wait_for_job_sensor.py
@@ -31,12 +31,10 @@ class XplentyWaitForJobSensorTestCase(unittest.TestCase):
             key='xplenty_job_outputs', value='donezo!')
 
     def test_poke_with_stopped_job(self):
-        self.stub_get_job(status='stopped', outputs='terminated!')
-        self.task_instance.xcom_push = MagicMock()
-        poke = self.operator.poke({'task_instance': self.task_instance})
-        self.assertEqual(True, poke)
-        self.task_instance.xcom_push.assert_called_with(
-            key='xplenty_job_outputs', value='terminated!')
+        self.stub_get_job(status='stopped', errors='terminated!')
+        with self.assertRaises(Exception) as ctx:
+            self.operator.poke({'task_instance': self.task_instance})
+        self.assertEqual('Job failed: terminated!', str(ctx.exception))
 
     def test_poke_with_failed_job(self):
         self.stub_get_job(status='failed', errors='kaboom!')

--- a/tests/airflow_xplenty/operators/test_xplenty_wait_for_job_sensor.py
+++ b/tests/airflow_xplenty/operators/test_xplenty_wait_for_job_sensor.py
@@ -1,13 +1,16 @@
 import unittest
+
 from mock import MagicMock
 from mock import Mock
+
 from airflow_xplenty.operators import XplentyWaitForJobSensor
 
 
 class XplentyWaitForJobSensorTestCase(unittest.TestCase):
     def setUp(self):
         self.operator = XplentyWaitForJobSensor(
-            start_job_task_id='start_job', task_id='test')
+            start_job_task_id="start_job", task_id="test"
+        )
         self.task_instance = Mock()
         self.task_instance.xcom_pull = MagicMock(return_value=314)
 
@@ -16,34 +19,35 @@ class XplentyWaitForJobSensorTestCase(unittest.TestCase):
         self.operator.client.get_job = MagicMock(return_value=job)
 
     def test_poke_with_running_job(self):
-        self.stub_get_job(status='running', progress=0.5)
-        poke = self.operator.poke({'task_instance': self.task_instance})
+        self.stub_get_job(status="running", progress=0.5)
+        poke = self.operator.poke({"task_instance": self.task_instance})
         self.assertEqual(False, poke)
-        self.task_instance.xcom_pull.assert_called_with(task_ids='start_job')
+        self.task_instance.xcom_pull.assert_called_with(task_ids="start_job")
         self.operator.client.get_job.assert_called_once_with(314)
 
     def test_poke_with_completed_job(self):
-        self.stub_get_job(status='completed', outputs='donezo!')
+        self.stub_get_job(status="completed", outputs="donezo!")
         self.task_instance.xcom_push = MagicMock()
-        poke = self.operator.poke({'task_instance': self.task_instance})
+        poke = self.operator.poke({"task_instance": self.task_instance})
         self.assertEqual(True, poke)
         self.task_instance.xcom_push.assert_called_with(
-            key='xplenty_job_outputs', value='donezo!')
+            key="xplenty_job_outputs", value="donezo!"
+        )
 
     def test_poke_with_stopped_job(self):
-        self.stub_get_job(status='stopped', errors='terminated!')
+        self.stub_get_job(status="stopped", errors="terminated!")
         with self.assertRaises(Exception) as ctx:
-            self.operator.poke({'task_instance': self.task_instance})
-        self.assertEqual('Job failed: terminated!', str(ctx.exception))
+            self.operator.poke({"task_instance": self.task_instance})
+        self.assertEqual("Job failed: terminated!", str(ctx.exception))
 
     def test_poke_with_failed_job(self):
-        self.stub_get_job(status='failed', errors='kaboom!')
+        self.stub_get_job(status="failed", errors="kaboom!")
         with self.assertRaises(Exception) as ctx:
-            self.operator.poke({'task_instance': self.task_instance})
-        self.assertEqual('Job failed: kaboom!', str(ctx.exception))
+            self.operator.poke({"task_instance": self.task_instance})
+        self.assertEqual("Job failed: kaboom!", str(ctx.exception))
 
     def test_poke_with_no_xcoms(self):
         self.task_instance.xcom_pull = MagicMock(return_value=None)
         with self.assertRaises(Exception) as ctx:
-            self.operator.poke({'task_instance': self.task_instance})
-        self.assertEqual('No job_id found in XComs', str(ctx.exception))
+            self.operator.poke({"task_instance": self.task_instance})
+        self.assertEqual("No job_id found in XComs", str(ctx.exception))


### PR DESCRIPTION
When an Xplenty job is "Stopped", it's unlikely it finished doing what it was meant to do. Considering such a job as successful leads to errors in DAGs due to expected files / tables / data not being present. Consider such Xplenty jobs as failures and raise an exception to fail the sensor.

Look at the first commit for actual changes